### PR TITLE
Rename extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# vscode-css-tractor
+# eCSStractor for VS Code
 
-![VS Code CSS tractor demo](src/assets/demo.gif?raw=true)
+![eCSStractor demo](src/assets/demo.gif?raw=true)
 
 Extracting selectors from HTML and generate CSS file.
 
@@ -13,7 +13,7 @@ Open any HTML file and do the following:
 1. Open the command palette
     - Press `Cmd + Shift + P` on macOS or `Ctrl + Shift + P` on Windows / Linux
     - Go to `View` → `Command Palette`
-1. Typing the `Run: CSS tractor` and select
+1. Typing the `Run: eCSStractor` and select
 
 Then will see new tab with CSS selectors extracted from HTML file.
 
@@ -31,7 +31,7 @@ Source:
 </ul>
 ```
 
-Run CSS tractor:
+Run eCSStractor:
 
 ```css
 #test-list {
@@ -49,4 +49,4 @@ In VS Code window:
 1. Open the extensions
     - Press `Cmd + Shift + P` on macOS or `Ctrl + Shift + P` on Windows / Linux
     - Go to `View` → `Extensions`
-1. Typing the `css-tractor` in input form and select `Install` on `CSS tractor`
+1. Typing the `ecsstractor` in input form and select `Install` on `eCSStractor`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "css-tractor",
+    "name": "ecsstractor",
     "version": "0.0.1",
     "lockfileVersion": 1,
     "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "css-tractor",
-  "displayName": "CSS tractor",
+  "name": "ecsstractor",
+  "displayName": "eCSStractor",
   "description": "Extracting selectors from HTML and generate CSS stylesheet",
   "version": "1.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kubosho/vscode-css-tractor.git"
+    "url": "https://github.com/kubosho/vscode-ecsstractor.git"
   },
   "publisher": "kubosho",
   "engines": {
@@ -20,7 +20,7 @@
     "commands": [
       {
         "command": "extension.run",
-        "title": "Run: CSS tractor"
+        "title": "Run: eCSStractor"
       }
     ]
   },

--- a/src/commands.js
+++ b/src/commands.js
@@ -13,7 +13,7 @@ async function runCSSTractor() {
   const content = document.getText()
 
   if (!supportedFormats.includes(document.languageId)) {
-    vscode.window.showErrorMessage('CSS tractor: not supported format.')
+    vscode.window.showErrorMessage('eCSStractor: not supported format.')
   }
 
   const selectors = [


### PR DESCRIPTION
`eCSStractor` means `extractor`. I didn't know this context.